### PR TITLE
Re-organizing codes to match Jamboard.

### DIFF
--- a/codes.md
+++ b/codes.md
@@ -263,10 +263,10 @@ more network like. Even later uses "layers" like a hierarchy. Let the "mind
 map" comes up as the impetus, so this may be all "map" with terms like
 concept and sub-concept (hierarchy) and "links"
         - "And then we have warehouses, homes, and apartments (gestures to each respective node in the graph), so this is kind of the basis (gestures to entire graph)."
-        - "what I would initially start with is the number of endpoints, like for instance, here warehouses and homes are endpoints because we are consideringthat as one unit. Whereas if we consider apartments, apartments will have number of residents, each resident will be an endpoint."
-	- "Particularly the layers it has, for instance now, as I said, there are multiple parameters. There were three parameters for each warehouse (EDIT: I think he means power plant), which were its customers, and then there were sublayers to that as well. For example,apartments and how each each apartment housed a certain number of residents. So the layers of the data... the layers each data type has is what intrigued me"
-        - "I’m also used to using the mind map techniques, so first laying out everything on paper and then seeing theproblem statement and connecting different parts of the problem."
-        - "Breaking down a particular problem or a particular concept into its sub-concepts and representing it on papers. And representing in such a way that it’s easier to link back onto to the main concepts."
+        - "what I would initially start with is the number of endpoints, like for instance, here warehouses and homes are endpoints because we are considering that as one unit. Whereas if we consider apartments, apartments will have number of residents, each resident will be an endpoint."
+		- "Particularly the layers it has, for instance now, as I said, there are multiple parameters. There were three parameters for each warehouse (EDIT: I think he means power plant), which were its customers, and then there were sublayers to that as well. For example, apartments and how each each apartment housed a certain number of residents. So the layers of the data... the layers each data type has is what intrigued me"
+        	- "I’m also used to using the mind map techniques, so first laying out everything on paper and then seeing theproblem statement and connecting different parts of the problem."
+       		- "Breaking down a particular problem or a particular concept into its sub-concepts and representing it on papers. And representing in such a way that it’s easier to link back onto to the main concepts."
     - Physical nesting:
       - It's unclear from these that the relations were considered explicit.
         This is anti-examples where something we could consider a hierarchy or

--- a/codes.md
+++ b/codes.md
@@ -1,322 +1,33 @@
+OUTSTANDING TODOs
+=================
+- See whose mental model changed (i.e. they say "yes, it changed by drawing" or if they used differing terms/visualizations/abstrations from the "gut reaction" question to the "did you mental model change by drawing" question)
+  - There's a code for refining mental models while drawing, but not for those
+    that did or did not change in a major way. We probably need them, possibly
+grouped by a code regarding mental model changes.
+- What are the different "obvious" groupings people used for the junk drawer?
+  - This suggests a grouping code under mental models, speaking of diversity
+- Count the number of people who add annotations when talking (connects to Future Work)
+  - this is done to some respect under Communication theme
+- People naturally try to find groups, the outlier sticks out (but the definition of "outlier" is loose) 
+  - This also suggests a grouping code under mental model
+
 Formatting conventions
 ======================
 
-## Codes and categories should be written as first-level headers
-  - Discrete supporting evidence
-  - (or codes associated with categories)
-  - are listed as distinct bullet points
-
-Codes
-=====
-## Participants often want to add additional information, data that isn’t there
-  - Request data attributes to each item:
-    - File system
-      - [Session 009](https://osf.io/6n7pa/) - file sizes 
-    - Power Stations
-      - [Session 014](https://osf.io/dm3ak/) - power required per building
-      - [Session 017](https://osf.io/qmts9/) - number of people per house
-      - [Session 029](https://osf.io/bph2d/) - number of people per house
-        (possibly as average), geospatial coordinates of houses
-      - [Session 032](https://osf.io/bka6e/) - number of people per house, wattage
-    - Junk Drawer
-      - [Session 016](https://osf.io/d4efp/) - item costs/price, durability
-        vs. expendable
-
-  - Add relationships between items:
-    - File system
-      - [Session 012](https://osf.io/4aphc/) - add relationships between files
-      - [Session 030](https://osf.io/9jxy3/) - database IDs, code file types
-
-  - Adding names, naming system, or schema:
-    - File System
-      - [Session 018](https://osf.io/ydnb9/) - folder names, file IDs and
-        naming schema
-      - 
-  
-  - Observation by KI - Participants want to add a 'richness' to the data in lots of dimensions. This isn't their data so they want to put it into the context of what they know. However, different people suggest different attributes. People may only want different parts of a wide dataset.
-
-## Purpose-seeking
-
-In these codes, participants infer a bigger picture or task.
-
-### Participants want to uncover the purpose: “Why is the file system organized like this?,” “what are the power stations doing?”
-  - Make a story/context for the file system: 
-    - [Session 006](https://osf.io/kj4nt/)
-    - [Session 009](https://osf.io/6n7pa/)
-    - [Session 012](https://osf.io/4aphc/)
-
-### Participants want to discover ultima: For power plant, which one produces the most/least energy?   
-  - Supported by:
-    - [Session 011](https://osf.io/kaemj/)
-    - [Session 014](https://osf.io/dm3ak/)
-    - [Session 032](https://osf.io/bka6e/)
-  - Not Supported:
-    - [Session 008](https://osf.io/47sng/)
-
-### Participants suggest or assume other tasks
-  - Take inventory
-    - [Session 016](https://osf.io/d4efp/)
-  - Cleaning
-    - [Session 019](https://osf.io/z3j9f/) 
-  - Carrying
-    - [Session 022](https://osf.io/psv9g/) 
-  - Determine affected people and/or buildings
-    - [Session 029](https://osf.io/bph2d/)
-  - Math problem
-    - [Session 031](https://osf.io/cy3s4/)
-  - Present for scientific publication
-    - [Session 032](https://osf.io/bka6e/)
-
-### Participants suggest source of data, such as all being part of a toolbox
-  - [Session 007](https://osf.io/kxze2/) - stationary drawer
-  - [Session 010](https://osf.io/kedv9/) - office supplies
-  - [Session 013](https://osf.io/bgeh9/) - toolbox, electrician's toolbox
-  - [Session 016](https://osf.io/d4efp/) - office supplies
-  - [Session 017](https://osf.io/qmts9/) - municipal or power company guide
-  - [Session 020](https://osf.io/5rsjc/) - comes from residential part of city
-  - [Session 021](https://osf.io/v4nmf/) - relation suggested but unknown
-  - [Session 022](https://osf.io/psv9g/) - office supplies
-  - [Session 024](https://osf.io/742fb/) - comes from residentail neighborhood
-  - [Session 028](https://osf.io/4u63n/) - office items, pre-sorted
-  - [Session 030](https://osf.io/9jxy3/) - organization of some program
-
-## Comparison to Findings in Walny et. al ["An Exploratory Study of Data Sketching for Visual Representation"](http://research.jagoda.ca/selected-work/data-sketches)
-
-### Placing our sketches on the continuum
-
-![The numeracy-to-abstractness continuum of Walny et. al](./images/rep-continuum-4-RED.png)
-
-## All 3 Datasets (28 sketches)
-
-![The numeracy-to-abstractness continuum of all three datasets](./images/alldatasets-continuum.png)
-
-## File System Sketches (9 sketches)
-
-![The numeracy-to-abstractness continuum of the file system datasets. All of the file system sketches were Node Link or more abstract.](./images/filesystem-continuum.png)
-
-## Power Station Datasets (11 sketches)
-
-![The numeracy-to-abstractness continuum of the power station datasets. Sketches seem to be split: about 6 of them fall toward the Numeric side, while about 4 of them fall on Node Link or Sets](./images/powerstation-continuum.png)
-
-## Junk Drawer Datasets (9 sketches)
-
-![The numeracy-to-abstractness continuum of the junk drawer datasets. Nearly all the sketches were on the abstract end of the continuum, with two exceptions: one Bar Chart and one Table](./images/junkdrawer-continuum.png)
+## Themes are written as first-level headers
+  - Codes are written as next level, subcodes as following level
+  - Evidence is listed as bullet points.
 
 
-### Relation between "Including Extrinsic Information" (E3)/"Statements with Analytic Potential" (F) and the representation continuum
-  - This code relates to [Walny et. al's](http://research.jagoda.ca/assets/pubs/Walny2015-EuroVis.pdf) finding that "in our sample, the participants who submitted the most abstract sketches were among the participants whose data reports tended to be in categories E3 (including extrinsic information) and F (statements with analytic potential)."
-  - I decided to not look for E3 statements because our question "How did you come up with this idea?" asks for participants to connect their sketch or the data to their own lives, thus asks tem to include extrinsic information
-  - [Session 006](https://osf.io/pkqsm/): 
-    - F "[the files]could have some correlation between them [to explain their placement]"
-  - [Session 007](https://osf.io/kxze2/): 
-    - F "This is a drawer and I visualized this was probably in some 
-  sort of cabinet, so this would be the edge of the cabinet if the door was closed", "it’s something that someone will probably have in their drawer"
-  - [Session 008](https://osf.io/wb4r5/):
-    - F "I mean I don't know what their fuels are, I’m assuming they’re maybe coal-powered power plants."
-  - [Session 009](https://osf.io/es7w6/):
-    - F "I don’t know how big it is, at the end of the day, right, so the text file could be bigger...could be super big, could be smaller". Type F and not type D because they hypothesize about an attribute (file size) that is not included in the data set.
-  - [Session 010](https://osf.io/kedv9/):
-    - None, could be due to limitation of interview (muted, no talking, text only)
-  - [Session 011](https://osf.io/qj2pm/):
-    - D "Power station C might be one of the bigger ones, either that or B, even though they had smaller numbers almost"  
-  - [Session 012](https://osf.io/xbw3h/): 
-    - E "I don’t think is the most efficient way to do this...What I find a little odd is that there’s a folder next to the coding files."
-    - F "And next to that, next to both of them, I put “likely related” because when you put a text file and an image together like that, typically they’re related in some capacity."
-  - Session 013:
-    - F "I’m pretty sure it’s like a handy tool box... maybe an electrician’s tool box." 
-  - Session 014:
-    - D < a whole discussion on their mind map and how they would reduce down to a base unit of consumption to estimate the total amount of power produced by each power station >
-  - Session 015: 
-    - Possibly E "I guess since I’m imagining it physically, it would be cumbersome to have a folder inside a folder."
-  - Session 016:
-    - F "maybe there’s a better way to accurately display - because it sounds like this is someone inventorying the items in a desk or an office - andit’s “ok, we can make a count of six rubber bands,” but this isn’t showing the dollar value, essentially, or how someone might quantify the dollar value."
-  - Session 017: 
-    - F "I dunno, it's a power station, it’s probably a municipal guide or a power company’s guide to how to distribute power."
-  - Session 018:
-    - D4/E2 "F1 -- that’s where I had to make a decision. It’s at a different level so should it be FC? I decided “no.” So I decided on F1 to stick with the program of that level."
-  - Session 019: 
-    - E2 "It seems like when I cleaned out my desk when I retired. Where are 
-paperclips? (Laughing)"
-  - Session 020:
-    - F "Gut reaction huh? Hmm. It seems to mostly be a residential area. I see many homes listed, I only see a warehouse, so I would guess this is kind of a residential part of a town or a city."
+Themes & Codes
+==============
 
 
-## What is "Data"
+## Mental Models
 
-### The idea that data relates to tables is prevalent:   
+These codes describe observations about mental models and their formation.
 
-  - [Session 007](https://osf.io/kxze2/): 
-    Me: "Did it surprise you that we called it a data set?" 
-
-    S: I was expecting something more structured, maybe like a table or something. I guess I was expecting a table. Because that’s the most common form of storing data, like a spreadsheet or table, something like that. I guess this a valid data set, it’s got objects and quantities for those objects.  
-  - [Session 014](https://osf.io/gzw56/): 
-    N: "For instance, there was apartments, there was houses, there was homes, there were warehouses so the first thing I thought in my mind was how to arrange those in a table in order to get an idea of how much power each house or apartment would generate or require."
-  - [Session 019](https://osf.io/z3j9f/): "I think of, like I didn’t work with Excel very much, so I don’t think of data sets, but when I heard the term data sets, I really thought about the analysts I worked with and Excel data, and I thought of big data sets and grouping people by demographics, that kind of thing. I refer to data sets and I was familiar with them but I never thought of stuff like this as a data set." (junk drawer data set)
-  - [Session 030](https://osf.io/9jxy3/): [bonus image](https://osf.io/s7t2r/) 
-    E: "The other thing that comes to mind, if I were to try to map this out in some sort of normal relationship, then I might think of having a folders table, a files table, and the file table..."
-
-### Other hesitation regarding whether we had given them data:
-
-  - [Session 007](https://osf.io/kxze2/): Data sets have objects and quantities "I guess this is a valid data set, it's got objects and quantities for
-    those objects"
-    - In vis, we don't always assume there are attributes
-  - [Session 010](https://osf.io/kedv9/): Thinks of something related to
-    computers as associated with the word "data"
-  - [Session 012](https://osf.io/xbw3h/): Whether they visualize data
-    regularly depends what counts as data
-  - [Session 014](https://osf.io/gzw56/): Dataset and data within are
-    different ideas: "like the emphasis should be on the data set, not the data containing in it, right?"
-  - [Session 019](https://osf.io/z3j9f/): Data analysis is grouping people by demographics: "I really thought about the analysts I worked with and Excel data, and I thought of big data sets and grouping people by demographics, that kind of thing."
-  - [Session 027](https://osf.io/q9cn5/): Participante didn't think of
-    folders/files given as data, but assumed data was what was contained
-inside those files
-
-
-## Explicitly-stated origins of data abstractions/mental models
-- Participants used file system icons that they cited as being from an operating system.
-  - [Session 006](https://osf.io/kj4nt/)
-  - [Session 009](https://osf.io/6n7pa/)
-  - [Session 012](https://osf.io/4aphc/)
-  - [Session 015](https://osf.io/y487f/)
-
-## Physical objects can also be used to represent data
-  - Their organization (e.g. orientation, appearance, affordances) is based on the real world
-
-    - Appearance: based on / tied to memories
-      - [Session 008](https://osf.io/47sng/): the cooling towers 
-      - [Session 013](https://osf.io/dgzrs/): the pencils, etc. 
-
-    - Affordances: 
-      - [Session 015](https://osf.io/y487f/): “physical” folder, issue of running out of space, words about putting things into the folder and it becoming out of shape: "Having a folder inside a folder, I guess. So that would - I guess since I’m imagining it physically, it would be cumbersome to have a folder inside a folder."
-
-## Participants tend to draw things in order of reading.
-  - Often, but not always, this order reflects itself on the page
-    - Support: File System and Power Station tend to be drawn in order of reading
-      - [Session 26](https://osf.io/mpncx/): intentionally gave the participant the power stations in non-alphabetical order. They drew a table, rows in alphabetical order, and then filled in the cells in read-order (not alphabetically).
-    - Against: junk drawer examples. We see organization on the page that is not related to the read-order but instead related to the physical objects
-      - [Session 016 Bonus](https://osf.io/u5dge/): this user came up with ways to arrange the data based on attributes that they added
-   - Temporal aspect of hypothesis forming on data reading seems interesting. I wonder how far
-     this has been pushed with respect to progressive visualizations.
-
-## People run into constraints with their existing sketch.
-
-  - People run out of space when drawing.
-
-    - [Session 007](https://osf.io/kxze2/): adds sharpies outside of pencil pouch because "I didn't make the pouch big enough."
-
-    - [Session 015](https://osf.io/zn6qj/): drew outline of open folder first and then drew smaller rectangles inside for the files, but ran out of space: "it's hard to draw this. I should've brought a pencil."
-
-    - [Session 016](https://osf.io/d4efp/): ran out of space drawing bars left to right, "I had to skip back here (left) to fill out the rest of the space."
-
-    - [Session 022](https://osf.io/psv9g/): would have "made the basket a little bigger."
-
-## People use text for clarity and understanding.
-  - *Note: use of text was only noted if the participant noted that they used text.*
-  - [Session 009](https://osf.io/es7w6/): calls the files ".java" so that "we can be more explicit."
-  - [Session 016](https://osf.io/d4efp/): participant "modified some of the descriptions" to help "me process a bit better." Switched to "noun, adjective."
-  - [Session 019](https://osf.io/z3j9f/): to communicate to another person, the participant said they would use lists
-  - [Session 021](https://osf.io/v4nmf/): used file "abbreviation" based on "knowing what text files look like" and "makes sense to me." For the code files, didn't know what the code was, so "I just said 'two code'."
-  - [Session 027](https://osf.io/q9cn5/): "feel that when I use icons, unless it’s mutually understood by both people, it might confuse; or even I might forget what the notation actually stood for... You can't go wrong with text, and it's not long either." 
-  - [Session 030](https://osf.io/9jxy3/): used "common file extensions", but recognized they used a mix of "tokens" for the file types
-  - [Session 029](https://osf.io/bph2d/): asterisk footnote for residents per apartment
-
-## People add details for clarity and understanding.
-  - *Note: use of detail was only noted if the participant noted that they added detail on purpose.*
-  - [Session 012](https://osf.io/xbw3h/): added labels and arrows to suggest hypotheses about the nature of the files and their relations.
-  - [Session 015](https://osf.io/zn6qj/): added shading for clarity.
-  - [Session 019](https://osf.io/z3j9f/): suggests adding more detail to distinguish pens, pencils, and sharpies.
-  - [Session 020](https://osf.io/5rsjc/):suggests adding weights to directed arrows, "it would be an improvement."
-  - [Session 023](https://osf.io/t45ry/): added a scale. In a revised version they would "include power station letters somehow."
-  - [Session 031](https://osf.io/cy3s4/): wishes they added detail to help clarify what items were
-  - TODO: Do we add instances of all representations of objects/things that were more complicated than simple shapes?
-    - E.g. [Session 024](https://osf.io/742fb/) used squares for houses and long rectangles with 3-4 "little squares inside them" for windows to represent apartments. Is this an example of adding detail for clarity? The participant mentioned this distinction and that the squares were added as windows to the apartments.
-
-## Few participants drew a key/legend (e.g. "(house symbol) = house"), but participants often explained symbols when they didn't match the physical appearance of the object
-  - [Session 006](https://osf.io/pkqsm/): verbally explains the icons for the types of files.
-  - [Session 024](https://osf.io/742fb/): verbally explained that small squares represent homes.
-  - [Session 032](https://osf.io/bka6e/): made a legend
-
-
-## People identify when the drawing alone wouldn't make sense to another person.
-  - [Session 031](https://osf.io/cy3s4/): "between the pens and the pencils and the sharpies, you can’t really tell what they are. If I were to give it to somebody, they probably wouldn’t be able to tell -- to differentiate between those groups...I probably should have written 'envelopes' on them, or some type of -- you know, if somebody were to look at this, I don’t think they would know what I drew."
-
-
-Kate
-====
-
-## Affordances can be part of the mental model
-  - File System:
-      - [Session 006](https://osf.io/pkqsm/) - describes mental model as subset of
-	of given data as they navigate it, similar to Windows
-      - [Session 012](https://osf.io/xbw3h/) - drawing notes interaction,
-	discussion mentions the drawing cannot be interactive
-      - [Session 021](https://osf.io/v4nmf/) - participant describes drawing for
-	others as recreating idea of what interactions would be in place
-      - [Session 030](https://osf.io/9jxy3/) - when asked about idea, they talk
-	about the interactions to navigate the hierarchy
-      - [Session 033](https://osf.io/uj34p/) - inset to show nested folder
-        confirmed to include interaction
-  - Junk Drawer
-    - [Session 022](https://osf.io/psv9g/) - basket drawn for carrying
-
-
-## People used abstractions in the depiction
-  - Voiced the abstraction from the beginning:
-    - [Session 011](https://osf.io/qj2pm/) - drew boxes because drawing houses
-      would be too difficult
-    - [Session 014](https://osf.io/gzw56/) - sketches idea of table rather
-      than full table
-    - [Session 024](https://osf.io/742fb/ ) - geospatial would have been
-      difficult to draw, so they chose an abstracted version to draw
-  - Used abstraction as drawing continued:
-    - [Session 008](https://osf.io/47sng/) - buildings were in 3D at first but
-      then switched to 2D icons
-    - [Session 009](https://osf.io/es7w6/) - originally text files labeled
-      with "txt" but participant says they stop labeling because of laziness
-
-## Mental model fixed at high level, but becomes more detailed in drawing
-  - Revised during drawing:
-     - [Session 006](https://osf.io/pkqsm/) - root added during discussion
-     - [Session 015](https://osf.io/zn6qj/) - rearrangement needed during
-       drawing process
-     - [Session 025](https://osf.io/z7w25/) - while drawing, participant comes
-       up with new grouping for writing implements
-     - [Session 026](https://osf.io/wfrc5/) - revised consideration of
-       building types with more information
-  - Becomes more detailed in drawing:
-     - [Session 020](https://osf.io/5rsjc/) - considers how it would scale
-       to 100 buildings during process
-     - [Session 025](https://osf.io/z7w25/) - while drawing, participant comes
-       up with new grouping for writing implements
-     - [Session 031](https://osf.io/cy3s4/) - item details considered during
-       drawing to clarify depiction
-     - [Session 033](https://osf.io/uj34p/) - icon detail/symbol choices not
-       thought about until drawing
-
-## Depiction changes for communication
-  - Same general abstraction
-      - [Session 006](https://osf.io/pkqsm/) - root added during discussion
-      - [Session 009](https://osf.io/es7w6/) - colors added when talking with
-	facilitator
-      - [Session 021](https://osf.io/v4nmf/) - tree drawn left-right to
-	communicate with others and attempt to add interaction indications
-      - [Session 031](https://osf.io/cy3s4/) - item details considered during
-	drawing to clarify depiction
-  - Different data abstraction
-      - [Session 026](https://osf.io/wfrc5/) - discusses various dataset
-	abstractions depending on audience "quantitative literacy"
-      - [Session 032](https://osf.io/bka6e/) - "better way" to represent,
-        possibly add table, other figures, captions
-
-
-## Difficulty in mental model abstractions with less math literacy
-  - [Session 023](https://osf.io/t45ry/) - participant has difficulty with
-    multidimensional aspect of power station data, drops the power station
-dimension
-  - [Session 031](https://osf.io/cy3s4/) - drew items as a list as given
-
-
-## There were a diversity of both typology-level data abstractions and idiom choices
+### There were a diversity of both typology-level data abstractions and idiom choices
   - It is hard to completely disassociate the typology from the idiom, this is
     best effort based on both the produced drawing and the way the participant
 spoke about the drawing and their mental model
@@ -392,45 +103,7 @@ spoke about the drawing and their mental model
       - Partitioned space:
         - [Session 028](https://osf.io/davzy/)
 
-## Ordering is diverse and often personal
-  - We may want to group this one with the one about people drawing in the
-    order things are given.
-  - We may also want to group this one with the "request for added data" or
-    "inferred added data" one. While the folders have the relationships given,
-the junk drawers do not, so those are inferred. Similarly, ordering is
-imposed, and categorization may either be desired or inferred or in this case,
-objected to with the folders.
-  
-  - Expressed personal preference:
-    - By category/type:
-      - [Session 006](https://osf.io/pkqsm/) - expressed desire to re-organize
-        folder contents to homogenize types
-      - [Session 012](https://osf.io/xbw3h/) - expressed desire to re-organize
-        folder contents to homogenize types
-      - [Session 016](https://osf.io/d4efp/) - by desired category of
-        "durability" based on personal experience
-      - [Session 021](https://osf.io/v4nmf/) - expressed desire to re-organize
-        folders contents to homogenize types, but suggested there may be a
-reasoning to the given organization that they cannot infer.
-    - By quantitative attribute:
-      - [Session 016](https://osf.io/d4efp/) - by desired attribute of
-        "price" based on personal experience
-    - By logical association:
-      - [Session 007](https://osf.io/kxze2/) - mental model/organization based
-        on own "junk drawer"
-      - [Session 019](https://osf.io/z3j9f/) - did not do this, but on
-        revision... "I would’ve put the pens and pencils and sharpies in the pencil pouch. The rubber bands and the tacks and the stamps in the small tray, and probably the envelopes in the big tray because I like to organize." 
-  - Reasoning unclear:
-    - By category/type:
-      - [Session 017](https://osf.io/qmts9/) - by residential vs. commercial
-    - By size:
-      - [Session 019](https://osf.io/z3j9f/) - consider organizing by size,
-        but did not do that, might have on revision if communicating to others
-    - By function:
-      - [Session 028](https://osf.io/4u63n/) - junk drawer items by function
-
-
-## Mental model starts forming immediately
+### Mental model starts forming immediately
   - Our first question asked about initial impressions/reactions. In this
     question, people already expressed ideas, including facets we found such
 as ordering and purpose-speaking.
@@ -495,7 +168,7 @@ as ordering and purpose-speaking.
     - [Session 032](https://osf.io/bka6e/) - "But I feel like in my head it’s the simplest conclusion."
     - [Session 033](https://osf.io/uj34p/) - "Yeah so obviously the text files are the ones with the two squigglys."
 
-## Ambiguity between trees & hierarchies & sets and their common visual idioms
+### Ambiguity between trees & hierarchies & sets and their common visual idioms
   - It was difficult to determine if the participant's mental model was what
     common dataset typologies would categorize as a tree versus a hierarchy
 versus a set. This may suggest a continuum. It may also suggest extra care be taken
@@ -614,9 +287,263 @@ second drawing uses proximity to divide durable from expendable
          they believed grouped together
 
 
-Alex 
-====
-## Aggregative marks and eliding details
+### Mental model fixed at high level, but becomes more detailed in drawing
+  - This code cross-references with the depiction theme
+  - Revised during drawing:
+     - [Session 006](https://osf.io/pkqsm/) - root added during discussion
+     - [Session 015](https://osf.io/zn6qj/) - rearrangement needed during
+       drawing process
+     - [Session 025](https://osf.io/z7w25/) - while drawing, participant comes
+       up with new grouping for writing implements
+     - [Session 026](https://osf.io/wfrc5/) - revised consideration of
+       building types with more information
+  - Becomes more detailed in drawing:
+     - [Session 020](https://osf.io/5rsjc/) - considers how it would scale
+       to 100 buildings during process
+     - [Session 025](https://osf.io/z7w25/) - while drawing, participant comes
+       up with new grouping for writing implements
+     - [Session 031](https://osf.io/cy3s4/) - item details considered during
+       drawing to clarify depiction
+     - [Session 033](https://osf.io/uj34p/) - icon detail/symbol choices not
+       thought about until drawing
+
+### Affordances can be part of the mental model
+  - File System:
+      - [Session 006](https://osf.io/pkqsm/) - describes mental model as subset of
+	of given data as they navigate it, similar to Windows
+      - [Session 012](https://osf.io/xbw3h/) - drawing notes interaction,
+	discussion mentions the drawing cannot be interactive
+      - [Session 021](https://osf.io/v4nmf/) - participant describes drawing for
+	others as recreating idea of what interactions would be in place
+      - [Session 030](https://osf.io/9jxy3/) - when asked about idea, they talk
+	about the interactions to navigate the hierarchy
+      - [Session 033](https://osf.io/uj34p/) - inset to show nested folder
+        confirmed to include interaction
+  - Junk Drawer
+    - [Session 022](https://osf.io/psv9g/) - basket drawn for carrying
+
+
+### Physical objects can also be used to represent data
+  - This code cross-references mental models, depictions, AND what-is-data,
+    but as these were what the participant thought of, we placed it here as
+the main one.
+  - Their organization (e.g. orientation, appearance, affordances) is based on the real world
+
+    - Appearance: based on / tied to memories
+      - [Session 008](https://osf.io/47sng/): the cooling towers 
+      - [Session 013](https://osf.io/dgzrs/): the pencils, etc. 
+
+    - Affordances: 
+      - [Session 015](https://osf.io/y487f/): “physical” folder, issue of running out of space, words about putting things into the folder and it becoming out of shape: "Having a folder inside a folder, I guess. So that would - I guess since I’m imagining it physically, it would be cumbersome to have a folder inside a folder."
+
+
+### Explicitly-stated origins of data abstractions/mental models
+- TODO: There is more evidence for this code, e.g., MIMO graphs
+- Participants used file system icons that they cited as being from an operating system.
+  - [Session 006](https://osf.io/kj4nt/)
+  - [Session 009](https://osf.io/6n7pa/)
+  - [Session 012](https://osf.io/4aphc/)
+  - [Session 015](https://osf.io/y487f/)
+
+
+### Difficulty in mental model abstractions with less math literacy
+  - [Session 023](https://osf.io/t45ry/) - participant has difficulty with
+    multidimensional aspect of power station data, drops the power station
+dimension
+  - [Session 031](https://osf.io/cy3s4/) - drew items as a list as given
+
+
+
+### Ordering
+
+These codes suggest how ordering arises in the mental model
+
+#### Ordering is diverse and often personal
+  - We may want to group this one with the one about people drawing in the
+    order things are given.
+  - We may also want to group this one with the "request for added data" or
+    "inferred added data" one. While the folders have the relationships given,
+the junk drawers do not, so those are inferred. Similarly, ordering is
+imposed, and categorization may either be desired or inferred or in this case,
+objected to with the folders. 
+    - TODO: Evidence under purpose-seeking for inferred links (mostly already
+      there)
+  - Expressed personal preference:
+    - By category/type:
+      - [Session 006](https://osf.io/pkqsm/) - expressed desire to re-organize
+        folder contents to homogenize types
+      - [Session 012](https://osf.io/xbw3h/) - expressed desire to re-organize
+        folder contents to homogenize types
+      - [Session 016](https://osf.io/d4efp/) - by desired category of
+        "durability" based on personal experience
+      - [Session 021](https://osf.io/v4nmf/) - expressed desire to re-organize
+        folders contents to homogenize types, but suggested there may be a
+reasoning to the given organization that they cannot infer.
+    - By quantitative attribute:
+      - [Session 016](https://osf.io/d4efp/) - by desired attribute of
+        "price" based on personal experience
+    - By logical association:
+      - [Session 007](https://osf.io/kxze2/) - mental model/organization based
+        on own "junk drawer"
+      - [Session 019](https://osf.io/z3j9f/) - did not do this, but on
+        revision... "I would’ve put the pens and pencils and sharpies in the pencil pouch. The rubber bands and the tacks and the stamps in the small tray, and probably the envelopes in the big tray because I like to organize." 
+  - Reasoning unclear:
+    - By category/type:
+      - [Session 017](https://osf.io/qmts9/) - by residential vs. commercial
+    - By size:
+      - [Session 019](https://osf.io/z3j9f/) - consider organizing by size,
+        but did not do that, might have on revision if communicating to others
+    - By function:
+      - [Session 028](https://osf.io/4u63n/) - junk drawer items by function
+
+#### Participants tend to draw things in order of reading.
+  - Often, but not always, this order reflects itself on the page
+    - Support: File System and Power Station tend to be drawn in order of reading
+      - [Session 26](https://osf.io/mpncx/): intentionally gave the participant the power stations in non-alphabetical order. They drew a table, rows in alphabetical order, and then filled in the cells in read-order (not alphabetically).
+    - Against: junk drawer examples. We see organization on the page that is not related to the read-order but instead related to the physical objects
+      - [Session 016 Bonus](https://osf.io/u5dge/): this user came up with ways to arrange the data based on attributes that they added
+   - Temporal aspect of hypothesis forming on data reading seems interesting. I wonder how far
+     this has been pushed with respect to progressive visualizations.
+
+
+
+## Purpose-Seeking
+
+In these codes, participants infer a bigger picture or task.
+
+### Participants often want to add additional information, data that isn’t there
+  - Request data attributes to each item:
+    - File system
+      - [Session 009](https://osf.io/6n7pa/) - file sizes 
+    - Power Stations
+      - [Session 014](https://osf.io/dm3ak/) - power required per building
+      - [Session 017](https://osf.io/qmts9/) - number of people per house
+      - [Session 029](https://osf.io/bph2d/) - number of people per house
+        (possibly as average), geospatial coordinates of houses
+      - [Session 032](https://osf.io/bka6e/) - number of people per house, wattage
+    - Junk Drawer
+      - [Session 016](https://osf.io/d4efp/) - item costs/price, durability
+        vs. expendable
+
+  - Add relationships between items:
+    - File system
+      - [Session 012](https://osf.io/4aphc/) - add relationships between files
+      - [Session 030](https://osf.io/9jxy3/) - database IDs, code file types
+    - Junk drawer
+      - [Session 007](https://osf.io/hsy7q/)
+      - [Session 013](https://osf.io/dgzrs/)
+
+  - Adding names, naming system, or schema:
+    - File System
+      - [Session 018](https://osf.io/ydnb9/) - folder names, file IDs and
+        naming schema
+  
+  - Observation by KI - Participants want to add a 'richness' to the data in lots of dimensions. This isn't their data so they want to put it into the context of what they know. However, different people suggest different attributes. People may only want different parts of a wide dataset.
+
+### Participants want to uncover the purpose: “Why is the file system organized like this?,” “what are the power stations doing?”
+  - Make a story/context for the file system: 
+    - [Session 006](https://osf.io/kj4nt/)
+    - [Session 009](https://osf.io/6n7pa/)
+    - [Session 012](https://osf.io/4aphc/)
+
+
+### Participants suggest or assume tasks:
+  - Participants want to discover ultima: For power plant, which one produces the most/least energy?   
+      - Supported by:
+	- [Session 011](https://osf.io/kaemj/)
+	- [Session 014](https://osf.io/dm3ak/)
+	- [Session 032](https://osf.io/bka6e/)
+      - Not Supported:
+	- [Session 008](https://osf.io/47sng/)
+  - Take inventory
+    - [Session 016](https://osf.io/d4efp/)
+  - Cleaning
+    - [Session 019](https://osf.io/z3j9f/) 
+  - Carrying
+    - [Session 022](https://osf.io/psv9g/) 
+  - Determine affected people and/or buildings
+    - [Session 029](https://osf.io/bph2d/)
+  - Math problem
+    - [Session 031](https://osf.io/cy3s4/)
+  - Present for scientific publication
+    - [Session 032](https://osf.io/bka6e/)
+
+### Participants suggest source of data, such as all being part of a toolbox
+  - [Session 007](https://osf.io/kxze2/) - stationary drawer
+  - [Session 010](https://osf.io/kedv9/) - office supplies
+  - [Session 013](https://osf.io/bgeh9/) - toolbox, electrician's toolbox
+  - [Session 016](https://osf.io/d4efp/) - office supplies
+  - [Session 017](https://osf.io/qmts9/) - municipal or power company guide
+  - [Session 020](https://osf.io/5rsjc/) - comes from residential part of city
+  - [Session 021](https://osf.io/v4nmf/) - relation suggested but unknown
+  - [Session 022](https://osf.io/psv9g/) - office supplies
+  - [Session 024](https://osf.io/742fb/) - comes from residentail neighborhood
+  - [Session 028](https://osf.io/4u63n/) - office items, pre-sorted
+  - [Session 030](https://osf.io/9jxy3/) - organization of some program
+
+
+
+## Depictions
+
+These codes collect observations about the drawing of the mental model and
+further embellishment.
+
+### People used abstractions in the depiction
+  - Voiced the abstraction from the beginning:
+    - [Session 011](https://osf.io/qj2pm/) - drew boxes because drawing houses
+      would be too difficult
+    - [Session 014](https://osf.io/gzw56/) - sketches idea of table rather
+      than full table
+    - [Session 024](https://osf.io/742fb/ ) - geospatial would have been
+      difficult to draw, so they chose an abstracted version to draw
+  - Used abstraction as drawing continued:
+    - [Session 008](https://osf.io/47sng/) - buildings were in 3D at first but
+      then switched to 2D icons
+    - [Session 009](https://osf.io/es7w6/) - originally text files labeled
+      with "txt" but participant says they stop labeling because of laziness
+
+### People run into constraints with their existing sketch.
+
+  - People run out of space when drawing.
+
+    - [Session 007](https://osf.io/kxze2/): adds sharpies outside of pencil pouch because "I didn't make the pouch big enough."
+
+    - [Session 015](https://osf.io/zn6qj/): drew outline of open folder first and then drew smaller rectangles inside for the files, but ran out of space: "it's hard to draw this. I should've brought a pencil."
+
+    - [Session 016](https://osf.io/d4efp/): ran out of space drawing bars left to right, "I had to skip back here (left) to fill out the rest of the space."
+
+    - [Session 022](https://osf.io/psv9g/): would have "made the basket a little bigger."
+
+
+### People use text for clarity and understanding.
+  - *Note: use of text was only noted if the participant noted that they used text.*
+  - [Session 009](https://osf.io/es7w6/): calls the files ".java" so that "we can be more explicit."
+  - [Session 016](https://osf.io/d4efp/): participant "modified some of the descriptions" to help "me process a bit better." Switched to "noun, adjective."
+  - [Session 019](https://osf.io/z3j9f/): to communicate to another person, the participant said they would use lists
+  - [Session 021](https://osf.io/v4nmf/): used file "abbreviation" based on "knowing what text files look like" and "makes sense to me." For the code files, didn't know what the code was, so "I just said 'two code'."
+  - [Session 027](https://osf.io/q9cn5/): "feel that when I use icons, unless it’s mutually understood by both people, it might confuse; or even I might forget what the notation actually stood for... You can't go wrong with text, and it's not long either." 
+  - [Session 030](https://osf.io/9jxy3/): used "common file extensions", but recognized they used a mix of "tokens" for the file types
+  - [Session 029](https://osf.io/bph2d/): asterisk footnote for residents per apartment
+
+
+### People add details for clarity and understanding.
+  - *Note: use of detail was only noted if the participant noted that they added detail on purpose.*
+  - [Session 012](https://osf.io/xbw3h/): added labels and arrows to suggest hypotheses about the nature of the files and their relations.
+  - [Session 015](https://osf.io/zn6qj/): added shading for clarity.
+  - [Session 019](https://osf.io/z3j9f/): suggests adding more detail to distinguish pens, pencils, and sharpies.
+  - [Session 020](https://osf.io/5rsjc/):suggests adding weights to directed arrows, "it would be an improvement."
+  - [Session 023](https://osf.io/t45ry/): added a scale. In a revised version they would "include power station letters somehow."
+  - [Session 031](https://osf.io/cy3s4/): wishes they added detail to help clarify what items were
+  - TODO: Do we add instances of all representations of objects/things that were more complicated than simple shapes?
+    - E.g. [Session 024](https://osf.io/742fb/) used squares for houses and long rectangles with 3-4 "little squares inside them" for windows to represent apartments. Is this an example of adding detail for clarity? The participant mentioned this distinction and that the squares were added as windows to the apartments.
+
+
+### Few participants drew a key/legend (e.g. "(house symbol) = house"), but participants often explained symbols when they didn't match the physical appearance of the object
+  - [Session 006](https://osf.io/pkqsm/): verbally explains the icons for the types of files.
+  - [Session 024](https://osf.io/742fb/): verbally explained that small squares represent homes.
+  - [Session 032](https://osf.io/bka6e/): made a legend
+
+### Aggregative marks and eliding details
 - Instances where participants used discrete aggregative marks in conjunction with concrete examples
   - [Session 012](https://osf.io/4aphc/)
     - "I marked it with a bunch of question marks to the right because I don't have any idea what [this folder] was for; it's just there"
@@ -625,7 +552,35 @@ Alex
   - [Session 009](https://osf.io/6n7pa/)
   - [Session 023](https://osf.io/t45ry/)
 
-## Drawn visualization techniques that the VIS community typically associates with a specific abstraction were sometimes inconsistent with other cues about how a participant thought about an abstraction
+
+
+## Communication
+
+These codes gather observations about the effect of communication on the
+mental model or depictions.
+
+KATY/ALEX: Is this a sub-code of depiction?
+
+### Depiction changes for communication
+  - This code cross-references wiht depiction
+  - Same general abstraction
+      - [Session 006](https://osf.io/pkqsm/) - root added during discussion
+      - [Session 009](https://osf.io/es7w6/) - colors added when talking with
+	facilitator
+      - [Session 021](https://osf.io/v4nmf/) - tree drawn left-right to
+	communicate with others and attempt to add interaction indications
+      - [Session 031](https://osf.io/cy3s4/) - item details considered during
+	drawing to clarify depiction
+  - Different data abstraction
+      - [Session 026](https://osf.io/wfrc5/) - discusses various dataset
+	abstractions depending on audience "quantitative literacy"
+      - [Session 032](https://osf.io/bka6e/) - "better way" to represent,
+        possibly add table, other figures, captions
+
+### People identify when the drawing alone wouldn't make sense to another person.
+  - [Session 031](https://osf.io/cy3s4/): "between the pens and the pencils and the sharpies, you can’t really tell what they are. If I were to give it to somebody, they probably wouldn’t be able to tell -- to differentiate between those groups...I probably should have written 'envelopes' on them, or some type of -- you know, if somebody were to look at this, I don’t think they would know what I drew."
+
+### Terminology used by participant in conflict with vis community language of dataset abstractions
 - Instances where participants drew a table, even though their description was very non-tabular
   - [Session 014](https://osf.io/dm3ak/)
 - Instances where participants drew something more like a node-link diagram, even though their description was more set-like
@@ -635,22 +590,102 @@ Alex
   - [Session 009](https://osf.io/6n7pa/)
 
 
-Items of interest
-=================
-- See whose mental model changed (i.e. they say "yes, it changed by drawing" or if they used differing terms/visualizations/abstrations from the "gut reaction" question to the "did you mental model change by drawing" question)
-- What are the different "obvious" groupings people used for the junk drawer?
-- Count the number of people who add annotations when talking (connects to Future Work)
-- People naturally try to find groups, the outlier sticks out (but the definition of "outlier" is loose)
+
+## Beliefs about Data
+
+These codes gather pre-conceptions participants had about the concepts of data
+and data analysis.
+
+### The idea that data relates to tables is prevalent:   
+
+  - [Session 007](https://osf.io/kxze2/): 
+    Me: "Did it surprise you that we called it a data set?" 
+
+    S: I was expecting something more structured, maybe like a table or something. I guess I was expecting a table. Because that’s the most common form of storing data, like a spreadsheet or table, something like that. I guess this a valid data set, it’s got objects and quantities for those objects.  
+  - [Session 014](https://osf.io/gzw56/): 
+    N: "For instance, there was apartments, there was houses, there was homes, there were warehouses so the first thing I thought in my mind was how to arrange those in a table in order to get an idea of how much power each house or apartment would generate or require."
+  - [Session 019](https://osf.io/z3j9f/): "I think of, like I didn’t work with Excel very much, so I don’t think of data sets, but when I heard the term data sets, I really thought about the analysts I worked with and Excel data, and I thought of big data sets and grouping people by demographics, that kind of thing. I refer to data sets and I was familiar with them but I never thought of stuff like this as a data set." (junk drawer data set)
+  - [Session 030](https://osf.io/9jxy3/): [bonus image](https://osf.io/s7t2r/) 
+    E: "The other thing that comes to mind, if I were to try to map this out in some sort of normal relationship, then I might think of having a folders table, a files table, and the file table..."
+
+### Other hesitation regarding whether we had given them data:
+
+  - [Session 007](https://osf.io/kxze2/): Data sets have objects and quantities "I guess this is a valid data set, it's got objects and quantities for
+    those objects"
+    - In vis, we don't always assume there are attributes
+  - [Session 010](https://osf.io/kedv9/): Thinks of something related to
+    computers as associated with the word "data"
+  - [Session 012](https://osf.io/xbw3h/): Whether they visualize data
+    regularly depends what counts as data
+  - [Session 014](https://osf.io/gzw56/): Dataset and data within are
+    different ideas: "like the emphasis should be on the data set, not the data containing in it, right?"
+  - [Session 019](https://osf.io/z3j9f/): Data analysis is grouping people by demographics: "I really thought about the analysts I worked with and Excel data, and I thought of big data sets and grouping people by demographics, that kind of thing."
+  - [Session 027](https://osf.io/q9cn5/): Participante didn't think of
+    folders/files given as data, but assumed data was what was contained
+inside those files
 
 
 
-Still Developing
-================
+Comparison to Related Work
+==========================
 
-- Impose structure/hierarchy: for the junk drawer, some participants group items 
-  - [Session 007](https://osf.io/hsy7q/)
-  - [Session 013](https://osf.io/dgzrs/)
-  
+## Comparison to Findings in Walny et. al ["An Exploratory Study of Data Sketching for Visual Representation"](http://research.jagoda.ca/selected-work/data-sketches)
 
-- Impose structure/hierarchy: For the file system, a participant wanted to add names that reflected a folder hierarchy
-  - [Session 012](https://osf.io/4aphc/)
+### Placing our sketches on the continuum
+
+![The numeracy-to-abstractness continuum of Walny et. al](./images/rep-continuum-4-RED.png)
+
+## All 3 Datasets (28 sketches)
+
+![The numeracy-to-abstractness continuum of all three datasets](./images/alldatasets-continuum.png)
+
+## File System Sketches (9 sketches)
+
+![The numeracy-to-abstractness continuum of the file system datasets. All of the file system sketches were Node Link or more abstract.](./images/filesystem-continuum.png)
+
+## Power Station Datasets (11 sketches)
+
+![The numeracy-to-abstractness continuum of the power station datasets. Sketches seem to be split: about 6 of them fall toward the Numeric side, while about 4 of them fall on Node Link or Sets](./images/powerstation-continuum.png)
+
+## Junk Drawer Datasets (9 sketches)
+
+![The numeracy-to-abstractness continuum of the junk drawer datasets. Nearly all the sketches were on the abstract end of the continuum, with two exceptions: one Bar Chart and one Table](./images/junkdrawer-continuum.png)
+
+
+### Relation between "Including Extrinsic Information" (E3)/"Statements with Analytic Potential" (F) and the representation continuum
+  - This code relates to [Walny et. al's](http://research.jagoda.ca/assets/pubs/Walny2015-EuroVis.pdf) finding that "in our sample, the participants who submitted the most abstract sketches were among the participants whose data reports tended to be in categories E3 (including extrinsic information) and F (statements with analytic potential)."
+  - I decided to not look for E3 statements because our question "How did you come up with this idea?" asks for participants to connect their sketch or the data to their own lives, thus asks tem to include extrinsic information
+  - [Session 006](https://osf.io/pkqsm/): 
+    - F "[the files]could have some correlation between them [to explain their placement]"
+  - [Session 007](https://osf.io/kxze2/): 
+    - F "This is a drawer and I visualized this was probably in some 
+  sort of cabinet, so this would be the edge of the cabinet if the door was closed", "it’s something that someone will probably have in their drawer"
+  - [Session 008](https://osf.io/wb4r5/):
+    - F "I mean I don't know what their fuels are, I’m assuming they’re maybe coal-powered power plants."
+  - [Session 009](https://osf.io/es7w6/):
+    - F "I don’t know how big it is, at the end of the day, right, so the text file could be bigger...could be super big, could be smaller". Type F and not type D because they hypothesize about an attribute (file size) that is not included in the data set.
+  - [Session 010](https://osf.io/kedv9/):
+    - None, could be due to limitation of interview (muted, no talking, text only)
+  - [Session 011](https://osf.io/qj2pm/):
+    - D "Power station C might be one of the bigger ones, either that or B, even though they had smaller numbers almost"  
+  - [Session 012](https://osf.io/xbw3h/): 
+    - E "I don’t think is the most efficient way to do this...What I find a little odd is that there’s a folder next to the coding files."
+    - F "And next to that, next to both of them, I put “likely related” because when you put a text file and an image together like that, typically they’re related in some capacity."
+  - Session 013:
+    - F "I’m pretty sure it’s like a handy tool box... maybe an electrician’s tool box." 
+  - Session 014:
+    - D < a whole discussion on their mind map and how they would reduce down to a base unit of consumption to estimate the total amount of power produced by each power station >
+  - Session 015: 
+    - Possibly E "I guess since I’m imagining it physically, it would be cumbersome to have a folder inside a folder."
+  - Session 016:
+    - F "maybe there’s a better way to accurately display - because it sounds like this is someone inventorying the items in a desk or an office - andit’s “ok, we can make a count of six rubber bands,” but this isn’t showing the dollar value, essentially, or how someone might quantify the dollar value."
+  - Session 017: 
+    - F "I dunno, it's a power station, it’s probably a municipal guide or a power company’s guide to how to distribute power."
+  - Session 018:
+    - D4/E2 "F1 -- that’s where I had to make a decision. It’s at a different level so should it be FC? I decided “no.” So I decided on F1 to stick with the program of that level."
+  - Session 019: 
+    - E2 "It seems like when I cleaned out my desk when I retired. Where are 
+paperclips? (Laughing)"
+  - Session 020:
+    - F "Gut reaction huh? Hmm. It seems to mostly be a residential area. I see many homes listed, I only see a warehouse, so I would guess this is kind of a residential part of a town or a city."
+


### PR DESCRIPTION
This change also:
- integrates the developing codes/evidence with existing ones
- combines the ultima task with task-finding in general
- moves the items of interest to the top and renames as TODOs with comments
- adds a few TODOs throughout
- updates the formatting conventions
- sticks related work related findings at the bottom - possibly need to make those their own markdown file.